### PR TITLE
Fix category name

### DIFF
--- a/provider/cmd/pulumi-resource-splight/schema.json
+++ b/provider/cmd/pulumi-resource-splight/schema.json
@@ -4,7 +4,7 @@
     "keywords": [
         "splightplatform",
         "splight",
-        "category/infrastructure"
+        "infrastructure"
     ],
     "homepage": "https://www.splight-ai.com",
     "license": "Apache-2.0",


### PR DESCRIPTION
Hello!

This is to fix the category name in the schema file. This is causing the following error in our publishing pipeline, preventing this package from being published to the Pulumi Registry. 

```Error: getting category: getting the category from keywords: invalid category tag category/Infrastructure```


cc @smartinellimarco 
